### PR TITLE
Finish refactor that seperates content and trigger

### DIFF
--- a/px-dropdown-content.html
+++ b/px-dropdown-content.html
@@ -158,7 +158,8 @@
        * Updated when the selections change.
        */
       displayValueSelected: {
-        type: String
+        type: String,
+        notify: true
       },
       /**
        * An array that contains the list of items which show up in the dropdown.

--- a/px-dropdown-content.html
+++ b/px-dropdown-content.html
@@ -61,7 +61,7 @@
           selected-values="{{selectedValues}}"
           selected-items="{{selectedItems}}"
           attr-for-selected="{{selectBy}}">
-          <template is="dom-repeat" id="dropdownItems" items="{{items}}" strip-whitespace>
+          <template is="dom-repeat" id="dropdownItems" items="{{_computedItems}}" strip-whitespace>
             <div class="dropdown-option" key="{{item.key}}" val="{{item.val}}" disabled$="{{item.disabled}}" disable-select="{{item.disableSelect}}" on-mouseover="_hoverOn" on-mouseout="_hoverOff" title="{{item.val}}">
               <template is="dom-if" if="{{_showCheckmark(multi,mobile)}}">
                 <px-icon icon="px-utl:check" class="select-icon u-pr--"></px-icon>
@@ -98,30 +98,27 @@
     ],
 
     properties: {
-
       /**
        * Bind to a `<px-dropdown-trigger>` element. A tap on the trigger
        * will open the dropdown.
        */
        openTrigger: {
-        type: HTMLElement
+        type: HTMLElement,
+        observer: '_openTriggerChanged'
       },
-
       /**
        * A flag which reflects if the dropdown trigger has been clicked or not.
        */
       opened: {
         type: Boolean,
-        notify: true,
-        value: false
+        notify: true
       },
       /**
        * A flag which reflects whether the dropdown is being hovered over.
        */
       hover: {
         type: Boolean,
-        notify: true,
-        value: false
+        notify: true
       },
       /**
        * A CSS selector which specifies the bounding target the dropdown will be
@@ -135,8 +132,7 @@
        * outside of it. Set to true to prevent dropdown from closing.
        */
       preventCloseOnOutsideClick: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * If set to true, users are unable to clear out the dropdown
@@ -147,8 +143,7 @@
        * which requires a user to select at least one option).
        */
       disableClear: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * If set to true, users can still open the dropdown and click on items,
@@ -156,16 +151,14 @@
        * the dropdown is used as a menu instead of a form input.
        */
       disableSelect: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * The text that is displayed in the label of the dropdown.
        * Updated when the selections change.
        */
       displayValueSelected: {
-        type: String,
-        notify: true
+        type: String
       },
       /**
        * An array that contains the list of items which show up in the dropdown.
@@ -183,10 +176,7 @@
        */
       items: {
         type: Array,
-        notify: true,
-        value: function () {
-          return [];
-        }
+        notify: true
       },
       /**
        * If set to true, multiple values can be selected in the dropdown.
@@ -194,8 +184,7 @@
        * If set to false, a single selected value is reflected in `selected`.
        */
       multi: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * Which property of each dropdown item will be used to get/set
@@ -203,7 +192,7 @@
        */
       selectBy: {
         type: String,
-        value: 'key'
+        observer: '_updateSelection'
       },
       /**
        * Gets or sets the selected item when `multi` is false.
@@ -211,7 +200,6 @@
        */
       selected: {
         type: String,
-        value: null,
         notify: true
       },
       /**
@@ -220,9 +208,6 @@
        */
       selectedValues: {
         type: Array,
-        value: function() {
-          return [];
-        },
         notify: true
       },
       /**
@@ -230,9 +215,6 @@
        */
       selectedItems: {
         type: Array,
-        value: function() {
-          return [];
-        },
         readOnly: true
       },
       /**
@@ -241,23 +223,20 @@
        * the page while the dropdown is open.
        */
       allowOutsideScroll: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * Whether the dropdown should be disabled and non-interactive.
        */
       disabled: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * If true, the dropdown will include a search box, whereby the
        * dropdown items can be filtered with a search term.
        */
       searchMode: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * The value of the search box, used for filtering the dropdown
@@ -265,7 +244,6 @@
        */
       searchTerm: {
         type: String,
-        value: '',
         observer: '_computeFilter'
       },
       /**
@@ -281,8 +259,7 @@
       * for the dropdown. Set this value if you use the `trigger` slot.
       */
       triggerHeight: {
-        type: Number,
-        value: 30
+        type: Number
       },
       /**
       * By default, the dropdown menu will be flush against the trigger.
@@ -290,8 +267,7 @@
       * in iconic menus and used by the application/product switcher.
       */
       showCaret: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
       * By default the dropdown will attempt to automatically align itself
@@ -299,8 +275,7 @@
       * to turn off that automatic behavior and force a certain `verticalAlign` / `horizontalAlign`.
       */
       disableDynamicAlign: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
       * Vertical alignment of the dropdown relative to the trigger.
@@ -309,8 +284,7 @@
       * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
       */
       verticalAlign: {
-        type: String,
-        value: 'top'
+        type: String
       },
       /**
       * Horizontal alignment of the dropdown relative to the trigger.
@@ -319,8 +293,7 @@
       * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
       */
       horizontalAlign: {
-        type: String,
-        value: 'left'
+        type: String
       },
       /**
       * Whether to display the mobile version of the dropdown, which appears as a fullscreen modal.
@@ -334,16 +307,14 @@
       * The breakpoint (in # of pixels) at which to display the mobile version of px-dropdown.
       */
       mobileAt: {
-        type: Number,
-        value: 400
+        type: Number
       },
       /**
       * By default, the mobile dropdown will show Apply/Clear buttons.
       * Set this property to hide them.
       */
       hideMobileButtons: {
-        type: Boolean,
-        value: false
+        type: Boolean
       },
       /**
        * A valid IETF language tag as a string that `app-localize-behavior` will
@@ -395,6 +366,16 @@
       _keyboardBeingUsed: {
         type: Boolean,
         value: false
+      },
+      /**
+       * Internal representation of the items array, in case simple strings are
+       * passed in, so that appropriate key/val pairs can be generated.
+       */
+       _computedItems: {
+        type: Array,
+        value: function () {
+          return [];
+        }
       }
     },
     listeners: {
@@ -403,9 +384,19 @@
       'iron-deselect' : '_handleDeselection'
     },
     observers: [
-      '_initSort(sortMode, items)'
+      '_itemsChanged(items, items.*)',
+      '_initSort(sortMode, _computedItems)'
     ],
-
+    created: function() {
+      this._handleOpenTriggerTappedBound = this.toggle.bind(this);
+      this._handleClearTappedBound = this._handleClearTapped.bind(this);
+      this._closeBound = this.close.bind(this);
+    },
+    attached: function() {
+      Polymer.RenderStatus.afterNextRender(this, () => {
+        this._updateSelection();
+      });
+    },
     toggle: function() {
       this.$.dropdown.toggle();
     },
@@ -414,6 +405,19 @@
     },
     open: function() {
       this.$.dropdown.open();
+    },
+    /**
+     * Bind to open trigger, open/close on trigger tap.
+     */
+    _openTriggerChanged(newTrigger, oldTrigger) {
+      if (oldTrigger && oldTrigger instanceof HTMLElement) {
+        oldTrigger.removeEventListener('click', this._handleOpenTriggerTappedBound);
+        oldTrigger.removeEventListener('clear-tapped', this._handleClearTappedBound);
+      }
+      if (newTrigger && newTrigger instanceof HTMLElement) {
+        newTrigger.addEventListener('click', this._handleOpenTriggerTappedBound, false);
+        newTrigger.addEventListener('clear-tapped', this._handleClearTappedBound, false);
+      }
     },
     _handleClearTapped: function() {
       this.set('selected', null);
@@ -424,6 +428,68 @@
         });
       }
       if(!this.mobile) this.$.dropdown.close();
+    },
+    /**
+     * Iterates over the `items` array and adds items with the
+     * `selected` property to the `selectedValues` array (for multi) or
+     * updates `selected` (for single). Note: if you specify more than
+     * one item as `selected` but `multi` is not enabled, only the *first*
+     * selected item will be chosen. Does NOT remove items if their selected
+     * property gets changed to false or removed - use `clearSelectionsOnChange`
+     * or mutate the `selected` / `selectedValues` properties instead.
+     */
+    _updateSelection: function() {
+      if(Array.isArray(this.items) && this.items.length > 0) {
+        if(this.multi) {
+          let length = this.items.length;
+          let selected = Array.isArray(this.selectedValues) ? this.selectedValues.slice(0) : [];
+          for(let i=0; i<length; i++) {
+            if(this.items[i].selected !== undefined && this.items[i].selected.toString() === 'true') {
+              if(selected && selected.indexOf(this.items[i][this.selectBy]) === -1) {
+                selected.push(this.items[i][this.selectBy]);
+              }
+            }
+          }
+          this.selectedValues = selected;
+        }
+        else {
+          let length = this.items.length;
+          let selected = this.selected;
+          for(let i=0; i<length; i++) {
+            if(this.items[i].selected !== undefined && this.items[i].selected.toString() === 'true') {
+              if(selected !== this.items[i][this.selectBy]) {
+                this.set('selected', this.items[i][this.selectBy]);
+                break;
+              }
+            }
+          }
+        }
+      }
+    },
+    /**
+     * Any time that `items` changes, this method will convert any
+     * simple strings in the array to an object with key/val.
+     */
+    _itemsChanged: function(items) {
+      if(items === undefined) return;
+      var newComputedItems = [];
+      if(items !== null) {
+        items.forEach(function(item, idx) {
+          if(typeof item === 'string') {
+            newComputedItems[idx] = {"key":idx, "val":item};
+          }
+          else {
+            newComputedItems[idx] = item;
+          }
+        }.bind(this));
+      }
+      this._computedItems = newComputedItems;
+      if(this.clearSelectionsOnChange) {
+        this.set('selected', null);
+        this.set('selectedValues', []);
+      }
+      this._updateSelection();
+      this._notifyResize();
     },
     /**
      * Searches the DOM for the `boundTarget` element.

--- a/px-dropdown-trigger.html
+++ b/px-dropdown-trigger.html
@@ -9,40 +9,33 @@
   <template>
     <style include="px-dropdown-styles"></style>
     <div class="trigger">
-      <slot name="trigger">
-        <div id="trigger" class$="dropdown-trigger btn {{_getDisabledClass(disabled)}} {{_getClass(buttonStyle)}}" tabindex="0">
-          <template is="dom-if" if="{{!_isEqual(buttonStyle,'icon')}}">
-            <div id="label" title="{{displayValueSelected}}" class="dropdown-label">{{displayValueSelected}}</div>
-          </template>
-          <template is="dom-if" if="{{_isEqual(buttonStyle,'icon')}}">
-            <px-icon class="custom-icon" icon="{{icon}}"></px-icon>
-          </template>
-          <template is="dom-if" if="{{_showClearButton(disableClear,buttonStyle,opened,selected,selectedValues,selectedValues.*)}}">
-            <px-icon class="dropdown-icon" icon="px-nav:close" on-tap="clear"></px-icon>
-          </template>
-          <template is="dom-if" if="{{_showChevron(disableClear,hideChevron,buttonStyle,opened,selected,selectedValues,selectedValues.*)}}">
-            <px-icon class="dropdown-icon" icon="px-utl:chevron"></px-icon>
-          </template>
-        </div>
-      </slot>
+      <div id="trigger" class$="dropdown-trigger btn {{_getDisabledClass(disabled)}} {{_getClass(buttonStyle)}}" tabindex="0">
+        <template is="dom-if" if="{{!_isEqual(buttonStyle,'icon')}}">
+          <div id="label" title="{{displayValueSelected}}" class="dropdown-label">{{displayValueSelected}}</div>
+        </template>
+        <template is="dom-if" if="{{_isEqual(buttonStyle,'icon')}}">
+          <px-icon class="custom-icon" icon="{{icon}}"></px-icon>
+        </template>
+        <template is="dom-if" if="{{_showClearButton(disableClear,buttonStyle,opened,selected,selectedValues,selectedValues.*)}}">
+          <px-icon class="dropdown-icon" icon="px-nav:close" on-tap="clear"></px-icon>
+        </template>
+        <template is="dom-if" if="{{_showChevron(disableClear,hideChevron,buttonStyle,opened,selected,selectedValues,selectedValues.*)}}">
+          <px-icon class="dropdown-icon" icon="px-utl:chevron"></px-icon>
+        </template>
+      </div>
     </div>
   </template>
 </dom-module>
 <script>
   Polymer({
-
     is: 'px-dropdown-trigger',
-
     behaviors: [
       Polymer.AppLocalizeBehavior
     ],
-
     listeners: {
       'tap' : '_handleTapped'
     },
-
     properties: {
-
       /**
        * A flag which reflects if the dropdown trigger has been clicked or not.
        */
@@ -51,7 +44,6 @@
         notify: true,
         value: false
       },
-
       /**
        * Read-only reference to the trigger element. Data-bind this property
        * into the px-context-browser `openTrigger` or `favoritedTrigger`
@@ -63,7 +55,6 @@
         notify: true,
         value: null
       },
-
       /**
        * Whether or not to hide the chevron icon from the dropdown.
        */
@@ -119,15 +110,12 @@
         value: ''
       }
     },
-
     attached() {
       this._setTrigger(this);
     },
-
     detached() {
       this._setTrigger(null);
     },
-
     /**
      * Fires an event to the main px-dropdown component to toggle the open state.
      */

--- a/px-dropdown.html
+++ b/px-dropdown.html
@@ -94,31 +94,33 @@ Custom property | Description
   <template>
     <style include="px-dropdown-styles"></style>
     <iron-media-query query$="(max-width: {{mobileAt}}px)" query-matches="{{mobile}}"></iron-media-query>
-    <px-dropdown-trigger
-      id="trigger"
-      trigger="{{openTrigger}}"
-      opened="[[opened]]"
-      language="[[language]]"
-      resources="[[resources]]"
-      use-key-if-missing="[[useKeyIfMissing]]"
-      disabled="[[disabled]]"
-      hide-chevron="[[hideChevron]]"
-      display-value="[[displayValue]]"
-      disable-clear="[[disableClear]]"
-      selected="[[selected]]"
-      selected-values="[[selectedValues]]"
-      button-style="[[buttonStyle]]"
-      icon="[[icon]]"
-      display-value-selected="{{_displayValueSelected}}">
-    </px-dropdown-trigger>
+    <div id="target">
+      <slot name="trigger" id="triggerSlot">
+        <px-dropdown-trigger
+          id="trigger"
+          opened="[[opened]]"
+          language="[[language]]"
+          resources="[[resources]]"
+          use-key-if-missing="[[useKeyIfMissing]]"
+          disabled="[[disabled]]"
+          hide-chevron="[[hideChevron]]"
+          display-value="[[displayValue]]"
+          disable-clear="[[disableClear]]"
+          selected="[[selected]]"
+          selected-values="[[selectedValues]]"
+          button-style="[[buttonStyle]]"
+          icon="[[icon]]"
+          display-value-selected="[[_displayValueSelected]]">
+        </px-dropdown-trigger>
+      </slot>
+    </div>
     <px-overlay-content
       hoist="[[hoist]]"
       container-type="[[containerType]]"
       event-names='["px-dropdown-click","px-dropdown-selection-changed"]'>
       <px-dropdown-content
         id="content"
-        open-trigger="[[openTrigger]]"
-        items="[[_computedItems]]"
+        items="[[items]]"
         multi="[[multi]]"
         opened="{{opened}}"
         key-bindings-target="[[_keyBindingsTarget]]"
@@ -154,24 +156,11 @@ Custom property | Description
 </dom-module>
 <script>
   Polymer({
-
     is: 'px-dropdown',
-
     behaviors: [
       PxOverlayBehavior.sharedProperties
     ],
-
     properties: {
-
-      /**
-       * Bind to a `<px-dropdown-trigger>` element. A tap on the trigger
-       * will open the dropdown.
-       */
-       openTrigger: {
-        type: HTMLElement,
-        observer: '_openTriggerChanged'
-      },
-
       /**
        * A flag which reflects if the dropdown trigger has been clicked or not.
        */
@@ -262,16 +251,6 @@ Custom property | Description
         }
       },
       /**
-       * Internal representation of the items array, in case simple strings are
-       * passed in, so that appropriate key/val pairs can be generated.
-       */
-       _computedItems: {
-        type: Array,
-        value: function () {
-          return [];
-        }
-      },
-      /**
        * If set to true, multiple values can be selected in the dropdown.
        * Selected values are reflected in the `selectedValues` property.
        * If set to false, a single selected value is reflected in `selected`.
@@ -286,8 +265,7 @@ Custom property | Description
        */
       selectBy: {
         type: String,
-        value: 'key',
-        observer: '_updateSelection'
+        value: 'key'
       },
       /**
        * Gets or sets the selected item when `multi` is false.
@@ -304,9 +282,6 @@ Custom property | Description
        */
       selectedValues: {
         type: Array,
-        value: function() {
-          return [];
-        },
         notify: true
       },
       /**
@@ -396,71 +371,70 @@ Custom property | Description
         value: false
       },
       /**
-      * The height of the trigger element, used for calculating offset distance
-      * for the dropdown. Set this value if you use the `trigger` slot.
-      */
+       * The height of the trigger element, used for calculating offset distance
+       * for the dropdown. Set this value if you use the `trigger` slot.
+       */
       triggerHeight: {
         type: Number,
         value: 30
       },
       /**
-      * By default, the dropdown menu will be flush against the trigger.
-      * Enable this property to show a caret between the two. Useful
-      * in iconic menus and used by the application/product switcher.
-      */
+       * By default, the dropdown menu will be flush against the trigger.
+       * Enable this property to show a caret between the two. Useful
+       * in iconic menus and used by the application/product switcher.
+       */
       showCaret: {
         type: Boolean,
         value: false
       },
       /**
-      * By default the dropdown will attempt to automatically align itself
-      * vertically and horizontally based on the available space. Set this flag
-      * to turn off that automatic behavior and force a certain `verticalAlign` / `horizontalAlign`.
-      */
+       * By default the dropdown will attempt to automatically align itself
+       * vertically and horizontally based on the available space. Set this flag
+       * to turn off that automatic behavior and force a certain `verticalAlign` / `horizontalAlign`.
+       */
       disableDynamicAlign: {
         type: Boolean,
         value: false
       },
       /**
-      * Vertical alignment of the dropdown relative to the trigger.
-      * Should be one of `top` or `bottom` where `top` means that the dropdown
-      * and trigger are aligned at the top, so the dropdown will extend _below_ the trigger.
-      * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
-      */
+       * Vertical alignment of the dropdown relative to the trigger.
+       * Should be one of `top` or `bottom` where `top` means that the dropdown
+       * and trigger are aligned at the top, so the dropdown will extend _below_ the trigger.
+       * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
+       */
       verticalAlign: {
         type: String,
         value: 'top'
       },
       /**
-      * Horizontal alignment of the dropdown relative to the trigger.
-      * Should be one of `left` or `right` where `left` means that the dropdown
-      * and trigger are aligned on their left side, so the dropdown will extend _to the right_.
-      * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
-      */
+       * Horizontal alignment of the dropdown relative to the trigger.
+       * Should be one of `left` or `right` where `left` means that the dropdown
+       * and trigger are aligned on their left side, so the dropdown will extend _to the right_.
+       * Overridden by dynamic alignment, unless `disableDynamicAlign` is true.
+       */
       horizontalAlign: {
         type: String,
-        value: 'left',
-        observer: '_changeHorizontal'
+        value: 'left'
       },
       /**
-      * Whether to display the mobile version of the dropdown, which appears as a fullscreen modal.
-      * Automatically detected based on the breakpoint specified in `mobileAt`.
-      */
+       * Whether to display the mobile version of the dropdown, which appears as a fullscreen modal.
+       * Automatically detected based on the breakpoint specified in `mobileAt`.
+       */
       mobile: {
         type: Boolean,
         reflectToAttribute: true
       },
       /**
-      * The breakpoint (in # of pixels) at which to display the mobile version of px-dropdown.
-      */
+       * The breakpoint (in # of pixels) at which to display the mobile version of px-dropdown.
+       */
       mobileAt: {
         type: Number,
         value: 400
       },
       /**
-      * By default, the mobile dropdown will show Apply/Clear buttons.
-      * Set this property to hide them.
-      */
+       * By default, the mobile dropdown will show Apply/Clear buttons.
+       * Set this property to hide them.
+       */
       hideMobileButtons: {
         type: Boolean,
         value: false
@@ -481,9 +455,9 @@ Custom property | Description
         value: true
       },
       /**
-      * A dictionary of strings used within the component for AppLocalizeBehavior
-      * to use, based on the selected `language` property.
-      */
+       * A dictionary of strings used within the component for AppLocalizeBehavior
+       * to use, based on the selected `language` property.
+       */
       resources: {
         type: Object,
         value: function() {
@@ -520,7 +494,6 @@ Custom property | Description
         type: Boolean,
         value: false
       },
-
       /**
        * Specifies if the dropdown content should get hoisted to a container in order to escape its current stacking context
        */
@@ -529,169 +502,72 @@ Custom property | Description
         value: false
       }
     },
-    observers: [
-      '_itemsChanged(items, items.*)'
-    ],
-    /**
-    * Bind to open trigger, open/close on trigger tap.
-    */
-    _openTriggerChanged(newTrigger, oldTrigger) {
-      if (oldTrigger && oldTrigger instanceof HTMLElement && this._handleOpenTriggerTapped) {
-        oldTrigger.removeEventListener('trigger-tapped', this._handleOpenTriggerTapped);
-        oldTrigger.removeEventListener('clear-tapped', this._handleClearTapped);
-        oldTrigger.removeEventListener('close-dropdown', this._close);
-      }
-      if (newTrigger && newTrigger instanceof HTMLElement) {
-        newTrigger.addEventListener('trigger-tapped', this._handleOpenTriggerTapped.bind(this), false);
-        newTrigger.addEventListener('clear-tapped', this._handleClearTapped.bind(this), false);
-        newTrigger.addEventListener('close-dropdown', this._close.bind(this), false);
-      }
+    created: function() {
+      /**
+       * Finds the trigger element and assigns it to the `openTrigger` property.
+       * Called when the element is first attached and whenever the `slotchange`
+       * event is fired.
+       */
+      this._initOpenTrigger = () => {
+        const trigger = this._getSlottedOpenTrigger();
+        if (trigger) {
+          this.$.content.openTrigger = trigger;
+        }
+      };
+    },
+    attached: function() {
+      this.$.triggerSlot.addEventListener('slotchange', this._initOpenTrigger, false);
+      this._initOpenTrigger();
+
+      Polymer.RenderStatus.afterNextRender(this, () => {
+        // Forces the width of the dropdown to be at least as wide as the trigger
+        this.$.content.style.minWidth = window.getComputedStyle(this.$.trigger).width;
+      });
+    },
+    detached: function() {
+      this.$.triggerSlot.removeEventListener('slotchange', this._initOpenTrigger);
     },
     /**
-     * Opens the dropdown when the button is pressed.
-     */
-    _handleOpenTriggerTapped: function() {
-      this.$.content.toggle();
-      // this.$.content.style.minWidth = window.getComputedStyle(this.$.trigger).width;
-    },
-    _close: function() {
-      this.$.content.close();
-    },
-    /**
-     * Clears all of the selections when the clear button is pressed.
-     */
-    _handleClearTapped: function(evt) {
-      evt.stopPropagation();
-      this.$.content._handleClearTapped();
-    },
-    /**
-     * Opens the dropdown when the button is pressed.
+     * Toggles visibility of the dropdown: opens dropdown if it is closed, and
+     * closes dropdown if it is open.
      */
     toggle: function() {
       this.$.content.toggle();
-      requestAnimationFrame(() => {
+      Polymer.RenderStatus.afterNextRender(this, () => {
         this.$.content.style.minWidth = window.getComputedStyle(this.$.trigger).width;
       });
     },
     /**
-     * Forces the width of the dropdown to be at least as wide as the trigger.
+     * Finds the element in the the trigger slot. If the developer passed an
+     * element into the `slot="trigger"` slot, returns that element. Otherwise
+     * returns the default trigger in the Shadow DOM. Works for Polymer 1.x and
+     * Polymer 2.x, which have different APIs for accomplishing this.
+     *
+     * @return {HTMLElement|null} - Reference to the trigger element, or null if none found
      */
-    attached: function() {
-      requestAnimationFrame(() => {
-        this.$.content.style.minWidth = window.getComputedStyle(this.$.trigger).width;
-        this._updateSelection();
-      });
-    },
-    /**
-     * Any time that `items` changes, this method will convert any
-     * simple strings in the array to an object with key/val.
-     */
-    _itemsChanged: function(items) {
-      if(items === undefined) return;
-      var newComputedItems = [];
-      if(items !== null) {
-        items.forEach(function(item, idx) {
-          if(typeof item === 'string') {
-            newComputedItems[idx] = {"key":idx, "val":item};
-          }
-          else {
-            newComputedItems[idx] = item;
-          }
-        }.bind(this));
+    _getSlottedOpenTrigger: function() {
+      let elems;
+      if (Polymer.Element) {
+        const nodes = Polymer.FlattenedNodesObserver.getFlattenedNodes(this.$.triggerSlot);
+        elems = nodes.filter(n => n.nodeType === Node.ELEMENT_NODE)
+      } else {
+        elems = this.getContentChildren('#triggerSlot');
       }
-      this._computedItems = newComputedItems;
-      if(this.clearSelectionsOnChange) {
-        this.set('selected', null);
-        this.set('selectedValues', []);
+      if (elems.length > 1) {
+        console.warn('Only expected 1 element as a child of the "trigger" slot.')
       }
-      this._updateSelection();
-      this._notifyResize();
+      const [trigger] = elems;
+      return (trigger instanceof HTMLElement) ? trigger : null;
     },
-    /**
-     * Iterates over the `items` array and adds items with the
-     * `selected` property to the `selectedValues` array (for multi) or
-     * updates `selected` (for single). Note: if you specify more than
-     * one item as `selected` but `multi` is not enabled, only the *first*
-     * selected item will be chosen. Does NOT remove items if their selected
-     * property gets changed to false or removed - use `clearSelectionsOnChange`
-     * or mutate the `selected` / `selectedValues` properties instead.
-     */
-    _updateSelection: function() {
-      if(this.items && this.items.length > 0) {
-        if(this.multi) {
-          var length = this.items.length,
-              selected = this.selectedValues,
-              i;
-          for(i=0; i<length; i++) {
-            if(this.items[i].selected !== undefined && this.items[i].selected.toString() === 'true') {
-              if(selected && selected.indexOf(this.items[i][this.selectBy]) === -1) {
-                selected.push(this.items[i][this.selectBy]);
-              }
-            }
-          }
-          this.set('selectedValues', []);
-          this.set('selectedValues', selected);
-        }
-        else {
-          var length = this.items.length,
-              selected = this.selected,
-              i;
-          for(i=0; i<length; i++) {
-            if(this.items[i].selected !== undefined && this.items[i].selected.toString() === 'true') {
-              if(selected !== this.items[i][this.selectBy]) {
-                this.set('selected', this.items[i][this.selectBy]);
-                break;
-              }
-            }
-          }
-        }
-      }
-    },
-    /**
-      * Event fired when any non-disabled element is clicked in the dropdown.
-      * If disableSelect is set on the entire dropdown or individual item,
-      * the event is still fired and the dropdown is closed, but the item
-      * is not selected. Useful for menu dropdowns, as opposed to selection dropdowns.
-      *
-      * @event px-dropdown-click
-      */
-    /**
-      * Event fired when any given element is selected or deselected in the list.
-      * `evt.detail` contains:
-      * ```
-      * { val: "text of the changed element",
-      *   key: "key of the changed element",
-      *   selected: true/false }
-      * ```
-      * @event px-dropdown-selection-changed
-      */
-    /**
-      * Event fired when any given element is selected or deselected in the list.
-      * `evt.detail` contains:
-      * ```
-      * { val: "text of the changed element",
-      *   key: "key of the changed element",
-      *   selected: true/false }
-      * ```
-      * @event px-dropdown-selection-changed
-      */
     /**
      * Resizes the dropdown when the search term is changed.
      */
     _notifyResize: function() {
-      this.$.content._notifyResize();
-    },
-    /**
-    * When horizontalAlign is `right`, the dropdown trigger should also align itself
-    * to the right side of the container.
-    */
-    _changeHorizontal: function() {
-      if(this.horizontalAlign === 'right') {
-        this.style.flexDirection = 'row-reverse';
-      }
-      else {
-        this.style.flexDirection = 'row';
-      }
+      // Debounce to try to stop notify resize from spamming with events, which
+      // slows things down in Polymer 2.x + IE
+      this.debounce('on-notify-resize', function() {
+        this.$.content._notifyResize();
+      }, 1);
     }
   });
 </script>

--- a/test/px-dropdown-custom-tests.js
+++ b/test/px-dropdown-custom-tests.js
@@ -108,6 +108,22 @@ describe('Custom Automation Tests for px-dropdown', function (done) {
     }
   );
 
+  it('Selecting an element changes _displayValueSelected property',
+    function (done) {
+      let dropdown_option = px_dropdown_content.querySelectorAll('.dropdown-option')[2];
+      var item_click = function (e) {
+        flush(function(){
+          assert.equal(px_dropdown._displayValueSelected, 'Three');
+          done();
+        });
+      };
+      assert.isUndefined(px_dropdown._displayValueSelected);
+      px_dropdown.addEventListener('px-dropdown-selection-changed', item_click);
+      dropdown_option.click();
+      px_dropdown.removeEventListener('px-dropdown-selection-changed', item_click);
+    }
+  );
+
   it('Compare passed items to what is on the dropdown itself',
     function (done) {
       let selector = px_dropdown.$.content.$.selector,


### PR DESCRIPTION
* Adds JS to dynamically watch for a trigger element to be
  added to the trigger slot so we can avoid breaking the API.
  We can't just pass the trigger down because in v1 Shadow DOM
  slots passed down twice that are empty still wipe out any
  default content.
* Removes default values from px-dropdown-content to avoid race
  conditions where default properties would get set in px-dropdown,
  get bound down into px-dropdown-content, lifecycle effects would
  run and update selected/selectedValues, then px-dropdown-content
  would have its default properties set and wipe out the work
  causing weird errors.
* Update tests.
* Refactor px-dropdown-content to just listen for click event
  emitting from the trigger
* Move all code that deals with items into px-dropdown-content
  to cleanly seperate concerns. px-dropdown is just a wrapper
  that connects the trigger and content together and passes
  properties and slotted content down.
